### PR TITLE
Update permanently_closed by business_status

### DIFF
--- a/src/VueGoogleAutocomplete.vue
+++ b/src/VueGoogleAutocomplete.vue
@@ -40,7 +40,7 @@
     */
     const BASIC_DATA_FIELDS = ['address_components', 'adr_address', 'alt_id',
         'formatted_address', 'geometry', 'icon', 'id', 'name',
-        'permanently_closed', 'photo', 'place_id', 'scope', 'type', 'url', 'vicinity'];
+        'business_status', 'photo', 'place_id', 'scope', 'type', 'url', 'vicinity'];
 
     export default {
         name: 'VueGoogleAutocomplete',


### PR DESCRIPTION
Resolve Google map API error : 
« permanently_closed is deprecated as of May 2020 and will beturned off in May 2021. Use business_status instead. »